### PR TITLE
feat!: move runCommand into the default export

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,7 @@ deno run --reload jsr:@hugojosefson/log-fold/example-concurrent-tasks
 captured stdout. It auto-creates a `logTask` with the command as the title.
 
 ```typescript
-import { logTask } from "@hugojosefson/log-fold";
-import { runCommand } from "@hugojosefson/log-fold/run-command";
+import { logTask, runCommand } from "@hugojosefson/log-fold";
 
 await logTask("Run innocuous npm commands", async () => {
   await runCommand(["npm", "search", "typescript"]);

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -5,7 +5,6 @@
   "license": "MIT",
   "exports": {
     ".": "./mod.ts",
-    "./run-command": "./src/run-command.ts",
     "./example-basic": "./readme/example-basic.ts",
     "./example-concurrent-tasks": "./readme/example-concurrent-tasks.ts",
     "./example-custom-options": "./readme/example-custom-options.ts",

--- a/mod.ts
+++ b/mod.ts
@@ -14,6 +14,14 @@ export type {
   StreamPair,
 } from "./src/log-from-stream.ts";
 
+// Subprocess wrapper
+export { runCommand } from "./src/run-command.ts";
+export type {
+  CommandArray,
+  RunCommandOptions,
+  RunCommandResult,
+} from "./src/run-command.ts";
+
 // Types
 export type { SessionOptions } from "./src/session.ts";
 export type { Spinner, TaskOptions } from "./src/task-node.ts";

--- a/readme/example-subprocess-wrapper.ts
+++ b/readme/example-subprocess-wrapper.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env -S deno run --allow-run=npm --allow-env
 
-import { logTask } from "../mod.ts";
-import { runCommand } from "../src/run-command.ts";
+import { logTask, runCommand } from "../mod.ts";
 
 await logTask("Run innocuous npm commands", async () => {
   await runCommand(["npm", "search", "typescript"]);

--- a/test/run-command.test.ts
+++ b/test/run-command.test.ts
@@ -1,8 +1,7 @@
 import { assertEquals, assertRejects } from "@std/assert";
 import { spawn } from "node:child_process";
-import { logFromStream, logTask } from "../mod.ts";
+import { logFromStream, logTask, runCommand } from "../mod.ts";
 import type { WriteStreamLike } from "../src/renderer/write-stream-like.ts";
-import { runCommand } from "../src/run-command.ts";
 
 /** Create a mock writable stream that collects output. */
 function mockStream(): WriteStreamLike & { lines: string[] } {


### PR DESCRIPTION
## Summary

- Export `runCommand`, `CommandArray`, `RunCommandOptions`, and `RunCommandResult` from the main entry point (`mod.ts`)
- Remove the separate `@hugojosefson/log-fold/run-command` subpath export from `deno.jsonc`
- Update example and test imports to use `../mod.ts` instead of `../src/run-command.ts`

**BREAKING CHANGE**: `import { runCommand } from "@hugojosefson/log-fold/run-command"` no longer works. Use `import { runCommand } from "@hugojosefson/log-fold"`.

Fixes #20